### PR TITLE
feat: GitHub Pages デプロイ（GitHub Actions）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
+  base: '/mkportforio/',
   plugins: [vue()],
   resolve: {
     alias: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

GitHub Pages（プロジェクトサイト）へ Vue + Vite アプリを公開するための設定を追加します。

## 変更内容

- **`.github/workflows/deploy.yml`**: `master` への push 時にビルドし、GitHub Actions 経由で Pages にデプロイ
- **`vite.config.ts`**: リポジトリ名に合わせ `base: '/mkportforio/'` を設定（ルーターは既に `import.meta.env.BASE_URL` を使用）

## マージ後の手順（リポジトリ管理者）

1. **Settings → Pages → Build and deployment → Source** を **GitHub Actions** に変更
2. 本 PR を `master` にマージ
3. `Deploy to GitHub Pages` ワークフローが成功すれば公開完了

## 公開 URL

https://mk0812.github.io/mkportforio/

## 補足

既存の `claude/github-pages-deploy-T3TGe` ブランチは `vite.config.ts` の base のみの変更です。本 PR は同設定に加え、デプロイ用ワークフローを含みます。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c83d39cb-5466-4764-b295-2047ae45d380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c83d39cb-5466-4764-b295-2047ae45d380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

