### PR TITLE
fix: Hero 3D の白飛びを抑制（bloom と fresnel ハイライト調整）

### DIFF
--- a/src/components/three/HeroCanvas.vue
+++ b/src/components/three/HeroCanvas.vue
@@ -219,7 +219,7 @@ async function initScene(root: HTMLDivElement, canvas: HTMLCanvasElement): Promi
       const bloomSize = new THREE.Vector2(1, 1)
       const c = new EffectComposer(renderer)
       c.addPass(new RenderPass(scene, camera))
-      c.addPass(new UnrealBloomPass(bloomSize, 0.55, 0.35, 0.45))
+      c.addPass(new UnrealBloomPass(bloomSize, 0.32, 0.4, 0.72))
       const postPass = new ShaderPass(localPostShader)
       postPass.renderToScreen = true
       c.addPass(postPass)

--- a/src/components/three/shaders/hero.frag.glsl
+++ b/src/components/three/shaders/hero.frag.glsl
@@ -21,11 +21,11 @@ void main() {
   vec3 col = mix(uColorA, uColorB, smoothstep(0.0, 0.6, tMix));
   col = mix(col, uColorC, smoothstep(0.5, 1.0, tMix));
 
-  float fres = pow(1.0 - clamp(dot(normalize(vNormal), normalize(vViewDir)), 0.0, 1.0), 2.2);
+  float fres = pow(1.0 - clamp(dot(normalize(vNormal), normalize(vViewDir)), 0.0, 1.0), 2.6);
   vec3 fresCol = mix(uColorA, uColorB, smoothstep(0.0, 0.55, fres));
   fresCol = mix(fresCol, uColorC, smoothstep(0.45, 1.0, fres));
-  col = mix(col, fresCol, fres * 0.72);
-  col += fres * 0.18;
+  col = mix(col, fresCol, fres * 0.6);
+  col += fres * 0.06;
 
   float causticA = abs(sin(vPos.x * 14.0 + vPos.y * 11.0 + t * 1.4));
   float causticB = abs(sin(vPos.z * 12.0 - vPos.x * 9.0 + t * 0.9));


### PR DESCRIPTION
UnrealBloomPass の strength/threshold を緩め、フレネル縁の加算ハイライトを
下げることで右側の白い発光で見づらくなっていた問題を解消。